### PR TITLE
Fix 32-bit overflow bug in 'dump' command

### DIFF
--- a/archive.c
+++ b/archive.c
@@ -812,8 +812,8 @@ archive_dump (const char *path, const char *prefix, const char *output)
     if (!fd)
       die ("Error opening output file %s\n", buffer);
     while (len > 0) {
-      int read;
-      u32 size = len;
+      u64 read;
+      u64 size = len;
 
       if (!open) {
         snprintf (buffer, sizeof(buffer), "%s/%s_%02d.dat", path, prefix, index);


### PR DESCRIPTION
Similar to #15, but for the "dump" command (otherwise the command would fail trying to read archive files that don't exist, because the remaining size wasn't properly updated, so the loop wasn't exited).